### PR TITLE
Issue #43: should we have function + ptr instead of a std::function f…

### DIFF
--- a/LATEST_RELEASE_NOTES.md
+++ b/LATEST_RELEASE_NOTES.md
@@ -7,6 +7,7 @@ Bugs addressed in this release:
 Other changes:
 
 * [#39](../../issues/39) Move to gtest
+* [#43](../../issues/43) should we have function + ptr instead of a std::function for callback?
 * [#44](../../issues/44) We should support short and int as well as float as format types
 
 

--- a/examples/SRCppExamples.cpp
+++ b/examples/SRCppExamples.cpp
@@ -95,7 +95,7 @@ int examplePullConverter()
         frames_left -= input_span.size();
         return input_span;
     };
-    auto puller = SRCpp::PullConverter<float>(
+    auto puller = SRCpp::PullConverter(
         callback, SRCpp::Type::Sinc_MediumQuality, channels, ratio);
 
     auto buffer = std::vector<float>(input.size() * ratio);

--- a/tests/SRCppTestPull.cpp
+++ b/tests/SRCppTestPull.cpp
@@ -73,6 +73,62 @@ TEST(SRCppPull, ReturningNone)
     EXPECT_EQ(data->size(), 0);
 }
 
+TEST(SRCppPull, TestFunctionAndContext)
+{
+    auto frames = 256;
+    auto input_frames = 64;
+    auto output_frames = size_t(16);
+    auto type = SRCpp::Type::Sinc_BestQuality;
+    auto factor = 0.9;
+    auto hz = std::vector<float> { 3000.0f, 40.0f };
+    auto channels = hz.size();
+    auto input = makeSin(hz, 48000.0, frames);
+
+    auto reference = CreatePushReference(input, channels, factor, type);
+
+    auto framesExpected
+        = static_cast<size_t>(std::ceil((input.size() / channels) * factor));
+    struct Context {
+        std::span<float> input_span;
+        int input_frames = 64;
+        size_t channels = 2;
+    };
+    auto context = Context {
+        .input_span = std::span<float>(input),
+        .input_frames = input_frames,
+        .channels = channels,
+    };
+    std::vector<float> output(framesExpected * channels);
+    // yes, there is a + there,
+    // https://stackoverflow.com/questions/18889028/a-positive-lambda-what-sorcery-is-this
+    auto callback = +[](void* context) -> std::span<float> {
+        auto context_ = static_cast<Context*>(context);
+        auto input_samples
+            = std::min(context_->input_frames * context_->channels,
+                context_->input_span.size());
+
+        auto result = context_->input_span.subspan(0, input_samples);
+        context_->input_span = context_->input_span.subspan(input_samples);
+        return result;
+    };
+    auto puller
+        = SRCpp::PullConverter(callback, &context, type, channels, factor);
+    auto framesProduced = 0UL;
+    while (framesProduced < framesExpected) {
+        auto toPull = std::min(output_frames, framesExpected - framesProduced);
+        auto pullBuffer = std::span { output.data() + framesProduced * channels,
+            toPull * channels };
+        auto [data, error] = puller.convert(pullBuffer);
+        if (!data.has_value()) {
+            throw std::runtime_error(error);
+        }
+        framesProduced += data->size() / channels;
+    }
+    output.resize(framesProduced * channels);
+
+    EXPECT_EQ(output, reference);
+}
+
 // TEST_CASE("Test returning 0, then returning more", "[SRCpp]")
 // {
 //     auto frames = 64;

--- a/tests/SRCppTestUtils.hpp
+++ b/tests/SRCppTestUtils.hpp
@@ -112,7 +112,7 @@ auto ConvertWithOnePull([[maybe_unused]] bool use_cpp20,
         input_span = input_span.subspan(input_samples);
         return result;
     };
-    auto puller = SRCpp::PullConverter<From>(callback, type, channels, factor);
+    auto puller = SRCpp::PullConverter(callback, type, channels, factor);
 #if SRCPP_USE_CPP23
     if (use_cpp20) {
 #endif // SRCPP_USE_CPP23


### PR DESCRIPTION
…or callback

Having a type erased object that will handle the input.  Type for From now gets deduced from the construction. This allows us to have other types of construction.